### PR TITLE
remove warning token address not checksummed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,9 +13,7 @@ export function validateSolidityTypeInstance(value: JSBI, solidityType: Solidity
 // warns if addresses are not checksummed
 export function validateAndParseAddress(address: string): string {
   try {
-    const checksummedAddress = getAddress(address)
-    warning(address === checksummedAddress, `${address} is not checksummed.`)
-    return checksummedAddress
+    return getAddress(address)
   } catch (error) {
     invariant(false, `${address} is not a valid address.`)
   }


### PR DESCRIPTION
Token address not checksummed seems a useless warning because we always parse it 

Uniswap sdk removed it too:
https://github.com/Uniswap/sdk-core/blob/main/src/utils/validateAndParseAddress.ts#L7:17